### PR TITLE
feat: add the search functionality for getbooks endpoint

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,0 +1,5 @@
+# TICK 1 INSTRUCTIONS
+## Matching Rules: The search should be case-insensitive and allow partial matches to enhance usability. For instance, searching "Potter" should return any titles or authors containing "Potter."
+## Priority of Results: Books that match multiple criteria (e.g., both title and author) should appear higher in the results than those matching only a single criterion. This one could be a bit more challenging so don't need to do it.
+## Result Limit: Limit search results to a maximum of 50 books per request to prevent overwhelming users.
+## Empty Results: If no matches are found, return aÂ 200 OKÂ status with an empty array, indicating a successful search with no results.

--- a/src/controllers/bookController.ts
+++ b/src/controllers/bookController.ts
@@ -1,9 +1,13 @@
 import { Request, Response } from "express";
 import * as bookService from "../services/bookService";
+import { BookQueryParams } from "../models/bookModel";
 
-export const getAllBooks = (req: Request, res: Response): void => {
+export const getBooks = (req: Request, res: Response): void => {
   try {
-    const books = bookService.getAllBooks();
+    // get the search conditions
+    const { title, author, genre }: BookQueryParams = req.query;
+    const books = bookService.getBooks(title, author, genre);
+
     res.status(200).json({ message: "Books retrieved", data: books });
   } catch (error) {
     res.status(500).json({ message: "Error retrieving books" });

--- a/src/models/bookModel.ts
+++ b/src/models/bookModel.ts
@@ -7,3 +7,9 @@ export interface Book {
   borrowerId?: string;
   dueDate?: string;
 }
+
+export interface BookQueryParams {
+  title?: string;
+  author?: string;
+  genre?: string;
+}

--- a/src/routes/bookRoutes.ts
+++ b/src/routes/bookRoutes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import {
-  getAllBooks,
+  getBooks,
   addBook,
   updateBook,
   deleteBook,
@@ -14,7 +14,7 @@ const router: Router = Router();
 /**
  * Define routes for book management
  */
-router.get("/", getAllBooks);
+router.get("/", getBooks);
 router.post("/", addBook);
 router.put("/:id", updateBook);
 router.delete("/:id", deleteBook);

--- a/src/services/bookService.ts
+++ b/src/services/bookService.ts
@@ -24,8 +24,41 @@ const books: Book[] = [
   },
 ];
 
-export const getAllBooks = (): Book[] => {
-  return books;
+export const getBooks = (
+  title: string | undefined,
+  author: string | undefined,
+  genre: string | undefined
+): Book[] => {
+  const resultBooks: [Book, number][] = [];
+  let returnBooks: Book[] = [];
+  const resultLimit: number = 50;
+  // if there is no condition, return all books
+  if (title === undefined && author === undefined && genre === undefined) {
+    return books;
+  }
+  // if there is condition, then do the searching
+  books.forEach((book) => {
+    let matchCount = 0;
+    if (title !== undefined && book.title.indexOf(title) !== -1) {
+      matchCount += 1;
+    }
+    if (author !== undefined && book.author.indexOf(author) !== -1) {
+      matchCount += 1;
+    }
+    if (genre !== undefined && book.genre.indexOf(genre) !== -1) {
+      matchCount += 1;
+    }
+    if (matchCount >= 1 && resultBooks.length < resultLimit) {
+      resultBooks.push([book, matchCount]);
+    }
+  });
+  // prioritize the result books accoring the relevant weight
+  resultBooks.sort((a, b) => b[1] - a[1]);
+  // get the reuslt only contain boos objects
+  resultBooks.forEach((book) => {
+    returnBooks.push(book[0]);
+  });
+  return returnBooks;
 };
 
 /**


### PR DESCRIPTION
for reviewer refer to:
Matching Rules: The search should be case-insensitive and allow partial matches to enhance usability. For instance, searching "Potter" should return any titles or authors containing "Potter."
Priority of Results: Books that match multiple criteria (e.g., both title and author) should appear higher in the results than those matching only a single criterion. This one could be a bit more challenging so don't need to do it.
Result Limit: Limit search results to a maximum of 50 books per request to prevent overwhelming users.
Empty Results: If no matches are found, return aÂ 200 OKÂ status with an empty array, indicating a successful search with no results.